### PR TITLE
Enhance language detection middleware

### DIFF
--- a/src/DetectRequestLocale.php
+++ b/src/DetectRequestLocale.php
@@ -15,10 +15,8 @@ class DetectRequestLocale
      */
     public function handle($request, Closure $next)
     {
-        $segment = $request->locale ?: $request->segment(1);
-
-        if (in_array($segment, locales())) {
-            app()->setLocale($segment);
+        if ($locale = $request->getPreferredLanguage(locales())) {
+            app()->setLocale($locale);
         }
 
         return $next($request);

--- a/src/DetectRequestLocale.php
+++ b/src/DetectRequestLocale.php
@@ -15,10 +15,27 @@ class DetectRequestLocale
      */
     public function handle($request, Closure $next)
     {
-        if ($locale = $request->getPreferredLanguage(locales())) {
+        if ($locale = $this->getLocaleFromRequest($request)) {
             app()->setLocale($locale);
         }
 
         return $next($request);
+    }
+
+    /**
+     * Guess the locale from request query, path or headers.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string|null
+     */
+    public function getLocaleFromRequest($request): ?string
+    {
+        $segment = $request->query('locale') ?: $request->segment(1);
+
+        if ($segment && in_array($segment, locales())) {
+            return $segment;
+        }
+
+        return $request->getPreferredLanguage(locales());
     }
 }


### PR DESCRIPTION
Update Laravel request language extraction to use the `getPreferredLanguage` method since the [`locale` property on the Symfony request class has protected access](https://github.com/symfony/http-foundation/blob/5.0/Request.php#L181).