### PR TITLE
Add defaults support to set default Route parameters

### DIFF
--- a/src/MultilingualRegistrar.php
+++ b/src/MultilingualRegistrar.php
@@ -39,7 +39,13 @@ class MultilingualRegistrar
     public function register(string $key, $handle, array $locales, array $options): RouteCollection
     {
         foreach ($locales as $locale) {
-            $this->registerRoute($key, $handle, $locale, $options);
+          $route =  $this->registerRoute($key, $handle, $locale, $options);
+
+          if (isset($options['defaults']) && is_array($options['defaults'])) {
+              foreach ( $options['defaults'] as $paramKey => $paramValue) {
+                  $route->defaults($paramKey, $paramValue);
+              }
+          }
         }
 
         return tap($this->router->getRoutes())->refreshNameLookups();

--- a/src/MultilingualRegistrar.php
+++ b/src/MultilingualRegistrar.php
@@ -39,13 +39,13 @@ class MultilingualRegistrar
     public function register(string $key, $handle, array $locales, array $options): RouteCollection
     {
         foreach ($locales as $locale) {
-          $route =  $this->registerRoute($key, $handle, $locale, $options);
+            $route = $this->registerRoute($key, $handle, $locale, $options);
 
-          if (isset($options['defaults']) && is_array($options['defaults'])) {
-              foreach ( $options['defaults'] as $paramKey => $paramValue) {
-                  $route->defaults($paramKey, $paramValue);
-              }
-          }
+            if (isset($options['defaults']) && is_array($options['defaults'])) {
+                foreach ($options['defaults'] as $paramKey => $paramValue) {
+                    $route->defaults($paramKey, $paramValue);
+                }
+            }
         }
 
         return tap($this->router->getRoutes())->refreshNameLookups();

--- a/src/MultilingualRoutePendingRegistration.php
+++ b/src/MultilingualRoutePendingRegistration.php
@@ -185,6 +185,19 @@ class MultilingualRoutePendingRegistration
     }
 
     /**
+     * Set default parameters values of the routes.
+     *
+     * @param  array  $defaults
+     * @return self
+     */
+    public function defaults(array $defaults): self
+    {
+        $this->options['defaults'] = $defaults;
+
+        return $this;
+    }
+        
+    /**
      * Handle the object's destruction.
      *
      * @return void

--- a/src/MultilingualRoutePendingRegistration.php
+++ b/src/MultilingualRoutePendingRegistration.php
@@ -196,7 +196,7 @@ class MultilingualRoutePendingRegistration
 
         return $this;
     }
-        
+
     /**
      * Handle the object's destruction.
      *

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -334,17 +334,17 @@ class RouteTest extends TestCase
     /** @test **/
     public function a_route_with_defaults_parameters_can_be_registered(): void
     {
-      $params = ['param_1'=>'value_1', 'param_2'=>'value_2'];
-      Route::multilingual('test')->defaults($params)->name('test');
+        $params = ['param_1'=>'value_1', 'param_2'=>'value_2'];
+        Route::multilingual('test')->defaults($params)->name('test');
 
-      foreach (config('locales.supported') as $locale) {
-        $route = \Route::getRoutes()->getByName($locale . '.test');
+        foreach (config('locales.supported') as $locale) {
+            $route = \Route::getRoutes()->getByName($locale.'.test');
 
-        foreach ($params as $key => $value) {
-          $this->assertArrayHasKey($key, $route->defaults);
-          $this->assertEquals($value, $route->defaults[$key]);
+            foreach ($params as $key => $value) {
+                $this->assertArrayHasKey($key, $route->defaults);
+                $this->assertEquals($value, $route->defaults[$key]);
+            }
         }
-      }
     }
 
     protected function registerTestRoute(): MultilingualRoutePendingRegistration

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -338,7 +338,7 @@ class RouteTest extends TestCase
         Route::multilingual('test')->defaults($params)->name('test');
 
         foreach (config('locales.supported') as $locale) {
-            $route = \Route::getRoutes()->getByName($locale.'.test');
+            $route = Route::getRoutes()->getByName($locale.'.test');
 
             foreach ($params as $key => $value) {
                 $this->assertArrayHasKey($key, $route->defaults);

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -331,6 +331,22 @@ class RouteTest extends TestCase
         $this->assertNotNull(route('prefix.fr.test'));
     }
 
+    /** @test **/
+    public function a_route_with_defaults_parameters_can_be_registered(): void
+    {
+      $params = ['param_1'=>'value_1', 'param_2'=>'value_2'];
+      Route::multilingual('test')->defaults($params)->name('test');
+
+      foreach (config('locales.supported') as $locale) {
+        $route = \Route::getRoutes()->getByName($locale . '.test');
+
+        foreach ($params as $key => $value) {
+          $this->assertArrayHasKey($key, $route->defaults);
+          $this->assertEquals($value, $route->defaults[$key]);
+        }
+      }
+    }
+
     protected function registerTestRoute(): MultilingualRoutePendingRegistration
     {
         $this->registerTestTranslations();


### PR DESCRIPTION
Hi,

I added the support to set defaults Route parameters using defaults() method.
It helps to avoid passing parameters to controllers in a closure so then the route can be cached & optimized.