### PR TITLE
Handle default Home registration with or without prefix

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -26,6 +26,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Home Prefix Configuration
+    |--------------------------------------------------------------------------
+    |
+    | The configuration option defines if the home route of the default locale
+    | should be prefixed.
+    |
+    */
+
+    'prefix_default_home' => env('MULTILINGUAL_ROUTES_PREFIX_DEFAULT_HOME', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Name Prefix Configuration
     |--------------------------------------------------------------------------
     |
@@ -35,4 +47,5 @@ return [
     */
 
     'name_prefix_before_locale' => env('MULTILINGUAL_ROUTES_NAME_PREFIX_BEFORE_LOCALE', false),
+
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -47,5 +47,4 @@ return [
     */
 
     'name_prefix_before_locale' => env('MULTILINGUAL_ROUTES_NAME_PREFIX_BEFORE_LOCALE', false),
-
 ];

--- a/src/MultilingualRegistrar.php
+++ b/src/MultilingualRegistrar.php
@@ -162,10 +162,7 @@ class MultilingualRegistrar
      */
     protected function generatePrefixForLocale(string $key, string $locale): ?string
     {
-        // dd(config('laravel-multilingual-routes.prefix_default_home'), $this->shouldNotPrefixDefaultHome($locale));
-        // if (($key == '/' && $this->shouldNotPrefixDefaultHome($locale)) || $this->shouldNotPrefixLocale($locale)) {
-            if (($key == '/' ) || $this->shouldNotPrefixLocale($locale)) {
-            // dd($key,  $locale);
+        if (($key == '/' ) || $this->shouldNotPrefixLocale($locale)) {
             return null;
         }
 

--- a/src/MultilingualRegistrar.php
+++ b/src/MultilingualRegistrar.php
@@ -162,7 +162,10 @@ class MultilingualRegistrar
      */
     protected function generatePrefixForLocale(string $key, string $locale): ?string
     {
-        if ($key == '/' || $this->shouldNotPrefixLocale($locale)) {
+        // dd(config('laravel-multilingual-routes.prefix_default_home'), $this->shouldNotPrefixDefaultHome($locale));
+        // if (($key == '/' && $this->shouldNotPrefixDefaultHome($locale)) || $this->shouldNotPrefixLocale($locale)) {
+            if (($key == '/' ) || $this->shouldNotPrefixLocale($locale)) {
+            // dd($key,  $locale);
             return null;
         }
 
@@ -179,7 +182,8 @@ class MultilingualRegistrar
     protected function generateUriFromKey(string $key, string $locale): string
     {
         if ($key == '/') {
-            return $this->shouldNotPrefixLocale($locale) ? '/' : "/$locale";
+            return $this->shouldNotPrefixLocale($locale) ||
+            $this->shouldNotPrefixDefaultHome($locale) ? '/' : "/$locale";
         }
 
         return Lang::has("routes.{$key}")
@@ -222,5 +226,17 @@ class MultilingualRegistrar
     {
         return $locale == config('laravel-multilingual-routes.default')
             && ! config('laravel-multilingual-routes.prefix_default');
+    }
+
+    /**
+     * Verify if we should not prefix the default Home Route.
+     *
+     * @param  string  $locale
+     * @return bool
+     */
+    protected function shouldNotPrefixDefaultHome(string $locale): bool
+    {
+        return $locale == config('laravel-multilingual-routes.default')
+            && ! config('laravel-multilingual-routes.prefix_default_home');
     }
 }

--- a/src/MultilingualRegistrar.php
+++ b/src/MultilingualRegistrar.php
@@ -162,7 +162,7 @@ class MultilingualRegistrar
      */
     protected function generatePrefixForLocale(string $key, string $locale): ?string
     {
-        if (($key == '/' ) || $this->shouldNotPrefixLocale($locale)) {
+        if ($key == '/' || $this->shouldNotPrefixLocale($locale)) {
             return null;
         }
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -355,7 +355,6 @@ class RouteTest extends TestCase
             'laravel-multilingual-routes.prefix_default_home' => true,
         ]);
 
-
         Route::multilingual('/', function () {
 
         })->name('home');

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -347,6 +347,39 @@ class RouteTest extends TestCase
         }
     }
 
+     /** @test **/
+    public function the_default_home_page_can_be_registered_with_prefix(): void
+    {
+        config([
+            'laravel-multilingual-routes.prefix_default' => true,
+            'laravel-multilingual-routes.prefix_default_home' => true,
+        ]);
+
+
+        Route::multilingual('/', function () {
+
+        })->name('home');
+
+        $this->assertEquals(url('en'), localized_route('home'));
+        $this->assertEquals(url('fr'), localized_route('home', [], 'fr'));
+    }
+
+    /** @test **/
+    public function the_default_home_page_can_be_registered_without_prefix(): void
+    {
+        config([
+            'laravel-multilingual-routes.prefix_default' => true,
+            'laravel-multilingual-routes.prefix_default_home' => false,
+        ]);
+
+        Route::multilingual('/', function () {
+
+        })->name('home');
+
+        $this->assertEquals(url(''), localized_route('home'));
+        $this->assertEquals(url('fr'), localized_route('home', [], 'fr'));
+    }
+
     protected function registerTestRoute(): MultilingualRoutePendingRegistration
     {
         $this->registerTestTranslations();

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -347,7 +347,7 @@ class RouteTest extends TestCase
         }
     }
 
-     /** @test **/
+    /** @test **/
     public function the_default_home_page_can_be_registered_with_prefix(): void
     {
         config([
@@ -356,7 +356,7 @@ class RouteTest extends TestCase
         ]);
 
         Route::multilingual('/', function () {
-
+            //
         })->name('home');
 
         $this->assertEquals(url('en'), localized_route('home'));
@@ -372,7 +372,7 @@ class RouteTest extends TestCase
         ]);
 
         Route::multilingual('/', function () {
-
+            //
         })->name('home');
 
         $this->assertEquals(url(''), localized_route('home'));


### PR DESCRIPTION
Hi !
I added this feature to give the option to get only Home default local without prefix and its others routes prefixed. It's very important for SEO.