### PR TITLE
fix: handle custom fallback for current_route on a 404 page (resoves #54)

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -19,6 +19,11 @@ if (! function_exists('current_route')) {
         }
 
         $route = Route::getCurrentRoute();
+
+        if (! $route) {
+            return $fallback;
+        }
+
         $name = Str::replaceFirst(
             locale().'.',
             "{$locale}.",

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -412,7 +412,7 @@ class RouteTest extends TestCase
 
         try {
             Route::dispatch(request());
-        } catch(NotFoundHttpException $e) {
+        } catch (NotFoundHttpException $e) {
             $this->assertEquals(
                 url('fallback'),
                 current_route('fr', url('fallback'))

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route;
 use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class RouteTest extends TestCase
 {
@@ -398,6 +399,25 @@ class RouteTest extends TestCase
             url('fallback'),
             current_route('fr', url('fallback'))
         );
+    }
+
+    /** @test **/
+    public function the_current_route_for_a_missing_page_will_return_the_custom_fallback(): void
+    {
+        Route::view('fallback', 'app');
+
+        app()->bind('request', static function () {
+            return Request::create(url('missing-route'), 'GET');
+        });
+
+        try {
+            Route::dispatch(request());
+        } catch(NotFoundHttpException $e) {
+            $this->assertEquals(
+                url('fallback'),
+                current_route('fr', url('fallback'))
+            );
+        }
     }
 
     /** @test **/


### PR DESCRIPTION
Resolves #54.