### PR TITLE
Fix issue that causes routes grouped with prefix to generate 404.

### DIFF
--- a/src/MultilingualRegistrar.php
+++ b/src/MultilingualRegistrar.php
@@ -213,7 +213,7 @@ class MultilingualRegistrar
      */
     protected function cleanUniqueRegistrationKey(Route $route, string $locale): Route
     {
-        return $route->setUri(str_replace("__{$locale}__", '', $route->uri));
+        return $route->setUri(rtrim(str_replace("__{$locale}__", '', $route->uri), '/'));
     }
 
     /**

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -46,7 +46,7 @@ class RouteTest extends TestCase
                 route($locale.'.test'),
                 localized_route('test', [], $locale)
             );
-            $this->assertNotNull(Route::getRoutes()->match(app(Request::class)->create(route($locale.'.test',[],false))));
+            $this->assertNotNull(Route::getRoutes()->match(app(Request::class)->create(route($locale.'.test', [], false))));
         }
     }
 
@@ -531,7 +531,7 @@ class RouteTest extends TestCase
 
     protected function registerGroupedTestRoute(): void
     {
-        Route::prefix('test')->group(function(){
+        Route::prefix('test')->group(function () {
             $this->registerTestRoute();
         });
     }

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -38,6 +38,19 @@ class RouteTest extends TestCase
     }
 
     /** @test **/
+    public function a_multilingual_group_routes_with_prefix_can_be_registered_and_accessed(): void
+    {
+        $this->registerGroupedTestRoute();
+        foreach (locales() as $locale) {
+            $this->assertEquals(
+                route($locale.'.test'),
+                localized_route('test', [], $locale)
+            );
+            $this->assertNotNull(Route::getRoutes()->match(app(Request::class)->create(route($locale.'.test',[],false))));
+        }
+    }
+
+    /** @test **/
     public function a_route_can_have_different_names_based_on_locales(): void
     {
         $this
@@ -516,7 +529,14 @@ class RouteTest extends TestCase
         );
     }
 
-    protected function registerTestTranslations()
+    protected function registerGroupedTestRoute(): void
+    {
+        Route::prefix('test')->group(function(){
+            $this->registerTestRoute();
+        });
+    }
+
+    protected function registerTestTranslations(): void
     {
         $this->registerTranslations([
             'en' => [


### PR DESCRIPTION
##Issue Reference
#50 


##Description
When multilingual route(s) is/are defined in a prefixed group, the routes generates 404 pages.

How To Test This?
```php

<?php

use Illuminate\Support\Facades\Route;

Route::get('/', function () {
    return view('welcome');
});

Route::group(['prefix' => 'blog'], function () {
    $c = App\Http\Controllers\BlogController::class;

    Route::multilingual('/', [$c, 'index'])->name('blog.index');
    Route::multilingual('/create', [$c, 'create'])->name('blog.create');
    Route::multilingual('/edit/{post}', [$c, 'edit'])->name('blog.edit');
    Route::multilingual('/show/{post}', [$c, 'show'])->name('blog.show');
});

```

Then navigate to /blog


##Extra Details
Only the root route "/" generates 404, whilst other routes with extra uri parts works just fine.


##Documentation
- Fixed when registering a multilingual routes grouped in a prefix.
- Added test cases to test if it can register grouped routes with a prefix and if the routes exists.
