### PR TITLE
feat: add PHP 8.1 and Laravel 9 to supported environments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['7.4', '8.0']
+        php: ['7.4', '8.0', '8.1']
         stability: [prefer-lowest, prefer-stable]
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['8.0', '8.1']
         stability: [prefer-lowest, prefer-stable]
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^8.0|^8.1",
         "chinleung/laravel-locales": "^2.0",
-        "illuminate/support": "^8.0|^9.0"
+        "illuminate/support": "^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^7.4|^8.0|^8.1",
         "chinleung/laravel-locales": "^1.2",
-        "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0"
+        "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.8|^4.0|^5.0|^6.0",
-        "phpunit/phpunit": "^8.0"
+        "orchestra/testbench": "^3.8|^4.0|^5.0|^6.0|^7.0",
+        "phpunit/phpunit": "^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0|^8.1",
-        "chinleung/laravel-locales": "^1.2",
-        "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0|^9.0"
+        "php": "^8.0|^8.1",
+        "chinleung/laravel-locales": "^2.0",
+        "illuminate/support": "^8.0|^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.8|^4.0|^5.0|^6.0|^7.0",
-        "phpunit/phpunit": "^8.0|^9.0"
+        "orchestra/testbench": "^7.0",
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR adds Laravel 9 and PHP 8.1 to supported environments and to the GitHub Actions test matrix.

Depends on https://github.com/chinleung/laravel-locales/pull/6 and a new release of https://github.com/chinleung/laravel-locales.