### PR TITLE
Add `hasLocalized` router macro

### DIFF
--- a/src/Macros/RouterMacros.php
+++ b/src/Macros/RouterMacros.php
@@ -29,4 +29,21 @@ class RouterMacros
             );
         };
     }
+
+    /**
+     * Check if a route with the given name exists for the current locale.
+     *
+     * @param  string|array  $name
+     * @return \Closure
+     */
+    public function hasLocalized(): Closure
+    {
+        return function ($name) {
+            $names = array_map(
+                static fn ($pattern) => locale() . ".{$pattern}",
+                is_array($name) ? $name : func_get_args(),
+            );
+            return $this->has($names);
+        };
+    }
 }

--- a/src/Macros/RouterMacros.php
+++ b/src/Macros/RouterMacros.php
@@ -40,9 +40,10 @@ class RouterMacros
     {
         return function ($name) {
             $names = array_map(
-                static fn ($pattern) => locale() . ".{$pattern}",
+                static fn ($pattern) => locale().".{$pattern}",
                 is_array($name) ? $name : func_get_args(),
             );
+
             return $this->has($names);
         };
     }

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -522,6 +522,17 @@ class RouteTest extends TestCase
         }
     }
 
+    /** @test **/
+    public function a_named_route_can_be_checked_if_it_exists(): void
+    {
+        $this
+            ->registerTestRoute()
+            ->name('foo');
+
+        $this->assertTrue(Route::hasLocalized('foo'));
+        $this->assertFalse(Route::hasLocalized('bar'));
+    }
+
     protected function registerTestRoute(): MultilingualRoutePendingRegistration
     {
         $this->registerTestTranslations();


### PR DESCRIPTION
I've added a `Route::hasLocalized` method, analogous to Laravel's `Route::has` method for checking if a named route exists:

```php
@if (Route::hasLocalized('login'))
    <a href="{{ localized_route('login') }}">{{ __('auth.login') }}</a>
@endif 
```