### PR TITLE
Add URL signing for localized routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,13 @@ Route::multilingual('contact')->redirect('support');
 Request::localizedRouteIs('home');
 ```
 
+### Signing localized routes
+
+```php
+URL::signedLocalizedRoute('unsubscribe', ['user' => 1]);
+URL::temporarySignedLocalizedRoute('unsubscribe', now()->addMinutes(30), ['user' => 1]);
+```
+
 ## Upgrading from 1.x to 2.x
 
 To update from 1.x to 2.x, you simply have to rename the namespace occurrences in your application from `LaravelMultilingualRoutes` to `MultilingualRoutes`. The most common use case would be the `DetectRequestLocale` middleware.

--- a/src/Macros/UrlGeneratorMacros.php
+++ b/src/Macros/UrlGeneratorMacros.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace ChinLeung\MultilingualRoutes\Macros;
+
+use Closure;
+
+class UrlGeneratorMacros
+{
+    /**
+     * Create a temporary signed route URL for a named route in the current
+     * locale.
+     *
+     * @param  string  $name
+     * @param  \DateTimeInterface|\DateInterval|int  $expiration
+     * @param  array  $parameters
+     * @param  bool  $absolute
+     * @return string
+     */
+    public function temporarySignedLocalizedRoute(): Closure
+    {
+        return function ($name, $expiration, $parameters = [], $absolute = true) {
+            return $this->signedLocalizedRoute($name, $parameters, $expiration, $absolute);
+        };
+    }
+
+    /**
+     * Create a signed route URL for a named route in the current
+     * locale.
+     *
+     * @param  string  $name
+     * @param  mixed  $parameters
+     * @param  \DateTimeInterface|\DateInterval|int|null  $expiration
+     * @param  bool  $absolute
+     * @return string
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function signedLocalizedRoute()
+    {
+        return function ($name, $parameters = [], $expiration = null, $absolute = true) {
+            return $this->signedRoute(locale().".{$name}", $parameters, $expiration, $absolute);
+        };
+    }
+}

--- a/src/MultilingualRoutesServiceProvider.php
+++ b/src/MultilingualRoutesServiceProvider.php
@@ -5,8 +5,10 @@ namespace ChinLeung\MultilingualRoutes;
 use ChinLeung\MultilingualRoutes\Macros\RedirectorMacros;
 use ChinLeung\MultilingualRoutes\Macros\RequestMacros;
 use ChinLeung\MultilingualRoutes\Macros\RouterMacros;
+use ChinLeung\MultilingualRoutes\Macros\UrlGeneratorMacros;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
+use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\ServiceProvider;
 
@@ -22,6 +24,7 @@ class MultilingualRoutesServiceProvider extends ServiceProvider
         Redirect::mixin(new RedirectorMacros);
         Request::mixin(new RequestMacros);
         Router::mixin(new RouterMacros);
+        UrlGenerator::mixin(new UrlGeneratorMacros);
 
         require __DIR__.'/helpers.php';
 

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ChinLeung\MultilingualRoutes\Tests;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\URL;
+use Orchestra\Testbench\TestCase;
+
+class UrlTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['locales.supported' => [
+            'en', 'fr',
+        ]]);
+    }
+
+    /** @test **/
+    public function a_multilingual_route_can_be_signed(): void
+    {
+        Route::multilingual('test');
+
+        $request = Request::create(URL::signedLocalizedRoute('test'));
+
+        $this->assertTrue(URL::hasValidSignature($request));
+        $this->assertTrue(str_starts_with($request->url(), localized_route('test')));
+    }
+
+    /** @test **/
+    public function a_multilingual_route_can_be_signed_with_temporary_signature(): void
+    {
+        Route::multilingual('test');
+
+        $request = Request::create(URL::temporarySignedLocalizedRoute('test', now()->addMinutes(30)));
+
+        $this->assertTrue(URL::hasValidSignature($request));
+        $this->assertTrue(str_starts_with($request->url(), localized_route('test')));
+
+        $this->travel(5)->hours();
+
+        $this->assertFalse(URL::hasValidSignature($request));
+    }
+}


### PR DESCRIPTION
I've implemented `signedLocalizedRoute` and `temporarySignedLocalizedRoute` macros for Laravel's `UrlGenerator`, analogous to `signedRoute` and `temporarySignedRoute`.

```php
use Illuminate\Support\Facades\URL;
 
return URL::signedLocalizedRoute('unsubscribe', ['user' => 1]);
```

```php
use Illuminate\Support\Facades\URL;
 
return URL::temporarySignedLocalizedRoute(
    'unsubscribe', now()->addMinutes(30), ['user' => 1]
);
```