### PR TITLE
Fix home route URI containing leading slash

### DIFF
--- a/src/MultilingualRegistrar.php
+++ b/src/MultilingualRegistrar.php
@@ -286,7 +286,7 @@ class MultilingualRegistrar
     protected function generateUriFromKey(string $key, string $locale): string
     {
         if ($key === '/') {
-            return $this->shouldNotPrefixHome($locale) ? '/' : "/{$locale}";
+            return $this->shouldNotPrefixHome($locale) ? '/' : $locale;
         }
 
         return Lang::has("routes.{$key}", $locale)


### PR DESCRIPTION
Some third party packages (for example [Ziggy](/tighten/ziggy), which is used by Breeze) have issues with the prefixed home URI containing a leading slash. This results in the home URL being rendered as `http://localhost//en` instead of `http://localhost/en`. Considering that Laravel's own Router removes leading slashes from URI's, I thought it might be appropriate to remove it here as well.