### PR TITLE
Support root routes in route groups

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,4 +36,4 @@ jobs:
           command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit --colors --verbose
+        run: vendor/bin/phpunit --colors

--- a/src/MultilingualRegistrar.php
+++ b/src/MultilingualRegistrar.php
@@ -269,7 +269,7 @@ class MultilingualRegistrar
      */
     protected function generatePrefixForLocale(string $key, string $locale): ?string
     {
-        if ($key === '/' || $this->shouldNotPrefixLocale($locale)) {
+        if (($key === '/' && !$this->router->getLastGroupPrefix()) || $this->shouldNotPrefixLocale($locale)) {
             return null;
         }
 

--- a/src/MultilingualRegistrar.php
+++ b/src/MultilingualRegistrar.php
@@ -269,7 +269,7 @@ class MultilingualRegistrar
      */
     protected function generatePrefixForLocale(string $key, string $locale): ?string
     {
-        if (($key === '/' && !$this->router->getLastGroupPrefix()) || $this->shouldNotPrefixLocale($locale)) {
+        if (($key === '/' && ! $this->router->getLastGroupPrefix()) || $this->shouldNotPrefixLocale($locale)) {
             return null;
         }
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -248,6 +248,23 @@ class RouteTest extends TestCase
     }
 
     /** @test **/
+    public function a_root_route_with_prefix_stack_can_be_registered(): void
+    {
+        $this->registerTestTranslations();
+
+        Route::prefix('prefix')->group(static function () {
+            Route::multilingual('/')->name('test');
+        });
+
+        $this->assertEquals(url('prefix'), localized_route('test'));
+
+        $this->assertEquals(
+            url('fr/prefixe'),
+            localized_route('test', [], 'fr')
+        );
+    }
+
+    /** @test **/
     public function a_view_route_can_be_registered(): void
     {
         Route::multilingual('/')->view('app')->name('home');
@@ -569,10 +586,12 @@ class RouteTest extends TestCase
         $this->registerTranslations([
             'en' => [
                 'routes.prefix/test' => 'prefix/test',
+                'routes.prefix' => 'prefix',
                 'routes.test' => 'test',
             ],
             'fr' => [
                 'routes.prefix/test' => 'prefixe/teste',
+                'routes.prefix' => 'prefixe',
                 'routes.test' => 'teste',
             ],
         ]);


### PR DESCRIPTION
Currently, the following route definition always drops the locale prefix:

```php
Route::prefix('prefix')->group(function () {
    Route::multilingual('/')->name('index');
});
```

`localized_route('index')` now always results in `/prefix` instead of `/{locale}/prefix` when applicable (regardless of settings).

I've modified `MultilingualRegistrar::generatePrefixForLocale` so that it doesn't drop the locale prefix when a group prefix applies.