### PR TITLE
Remove PHP 8.4 deprecation warning

### DIFF
--- a/src/MultilingualRoutePendingRegistration.php
+++ b/src/MultilingualRoutePendingRegistration.php
@@ -212,7 +212,7 @@ class MultilingualRoutePendingRegistration
      * @param  string|null  $locale
      * @return $this
      */
-    public function where($name, ?string $expression = null, string $locale = null): self
+    public function where($name, ?string $expression = null, ?string $locale = null): self
     {
         $key = rtrim("constraints-$locale", '-');
 


### PR DESCRIPTION
This PR fixes the deprecation warning that's showing up with PHP 8.4:

`ChinLeung\\MultilingualRoutes\\MultilingualRoutePendingRegistration::where(): Implicitly marking parameter $locale as nullable is deprecated, the explicit nullable type must be used instead in chinleung/laravel-multilingual-routes/src/MultilingualRoutePendingRegistration.php on line 215`